### PR TITLE
Minor improvements and a breaking change

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,7 +82,7 @@ def findLineFromObjectName(sourceFile, objectName):
 
 
 autodoc_mock_imports = ["torch", "torchtext", "tensorflow", "lightgbm", "sklearn", "seaborn", "psutil", "pyyaml",
-                        "sqlite3", "azureml", "mlflow", "MySQLdb", "catboost"]
+                        "sqlite3", "azureml", "mlflow", "MySQLdb", "catboost", "trains"]
 
 # Render docu of __init__ methods
 # autoclass_content = 'both'

--- a/src/sensai/evaluation/__init__.py
+++ b/src/sensai/evaluation/__init__.py
@@ -1,6 +1,6 @@
 from .crossval import VectorClassificationModelCrossValidator, VectorRegressionModelCrossValidator, \
     VectorClassificationModelCrossValidationData, VectorRegressionModelCrossValidationData
 from .eval_util import RegressionEvaluationUtil, ClassificationEvaluationUtil, MultiDataEvaluationUtil, \
-    evalModelViaEvaluator
+    evalModelViaEvaluator, createEvaluationUtil, createVectorModelEvaluator, createVectorModelCrossValidator
 from .evaluator import VectorClassificationModelEvaluator, VectorRegressionModelEvaluator, \
     VectorRegressionModelEvaluationData, VectorClassificationModelEvaluationData

--- a/src/sensai/evaluation/eval_stats/eval_stats_regression.py
+++ b/src/sensai/evaluation/eval_stats/eval_stats_regression.py
@@ -34,7 +34,7 @@ class RegressionMetricMAE(RegressionMetric):
 
     @classmethod
     def computeValue(cls, y_true: np.ndarray, y_predicted: np.ndarray):
-        return cls.computeAbsErrors(y_true, y_predicted)
+        return np.mean(cls.computeAbsErrors(y_true, y_predicted))
 
 
 class RegressionMetricMSE(RegressionMetric):

--- a/src/sensai/evaluation/eval_util.py
+++ b/src/sensai/evaluation/eval_util.py
@@ -148,6 +148,7 @@ class EvaluationUtil(ABC, Generic[TModel, TEvaluator, TEvalData, TCrossValidator
     def createEvaluator(self, model: TModel = None, isRegression: bool = None) -> TEvaluator:
         """
         Creates an evaluator holding the current input-output data
+
         :param model: the model for which to create an evaluator (just for reading off regression or classification,
             the resulting evaluator will work on other models as well)
         :param isRegression: whether to create a regression model evaluator. Either this or model have to be specified
@@ -159,6 +160,7 @@ class EvaluationUtil(ABC, Generic[TModel, TEvaluator, TEvalData, TCrossValidator
     def createCrossValidator(self, model: TModel = None, isRegression: bool = None) -> TCrossValidator:
         """
         Creates a cross-validator holding the current input-output data
+
         :param model: the model for which to create a cross-validator (just for reading off regression or classification,
             the resulting evaluator will work on other models as well)
         :param isRegression: whether to create a regression model cross-validator. Either this or model have to be specified

--- a/src/sensai/evaluation/eval_util.py
+++ b/src/sensai/evaluation/eval_util.py
@@ -291,7 +291,7 @@ class RegressionEvaluationUtil(EvaluationUtil[VectorRegressionModel, VectorRegre
         resultCollector.addFigure("scatter-gt-pred", evalStats.plotScatterGroundTruthPredictions(titleAdd=subtitle))
 
 
-class ClassificationEvaluationUtil(EvaluationUtil[VectorClassificationModel, VectorClassificationModelEvaluator, VectorClassificationModelCrossValidator, VectorClassificationModelEvaluationData, VectorClassificationModelCrossValidationData, ClassificationEvalStats]):
+class ClassificationEvaluationUtil(EvaluationUtil[VectorClassificationModel, VectorClassificationModelEvaluator, VectorClassificationModelEvaluationData, VectorClassificationModelCrossValidator, VectorClassificationModelCrossValidationData, ClassificationEvalStats]):
     def _createEvalStatsPlots(self, evalStats: ClassificationEvalStats, resultCollector: EvaluationUtil.ResultCollector, subtitle=None):
         resultCollector.addFigure("confusion-matrix", evalStats.plotConfusionMatrix(titleAdd=subtitle))
 

--- a/src/sensai/featuregen.py
+++ b/src/sensai/featuregen.py
@@ -609,6 +609,11 @@ class FeatureCollector(object):
     def getMultiFeatureGenerator(self) -> MultiFeatureGenerator:
         return self._multiFeatureGenerator
 
+    def getNormalizationRules(self, includeGeneratedCategoricalRules=True):
+        return self.getMultiFeatureGenerator().getNormalisationRules(
+            includeGeneratedCategoricalRules=includeGeneratedCategoricalRules
+        )
+
     def _createMultiFeatureGenerator(self):
         featureGenerators = []
         for f in self._featureGeneratorsOrNames:

--- a/src/sensai/tracking/trains_tracking.py
+++ b/src/sensai/tracking/trains_tracking.py
@@ -1,0 +1,41 @@
+import logging
+
+from ..tracking import TrackedExperiment
+
+from trains import Task
+
+log = logging.getLogger(__name__)
+
+
+# TODO: this is an initial working implementation, it should eventually be improved
+class TrackedTrainsExperiment(TrackedExperiment):
+    def __init__(self, task: Task = None, projectName: str = None, taskName: str = None,
+            additionalLoggingValuesDict=None):
+        """
+
+        :param task: instances of trains.Task
+        :param projectName: only necessary if task is not provided
+        :param taskName: only necessary if task is not provided
+        :param additionalLoggingValuesDict:
+        """
+        if task is None:
+            if projectName is None or taskName is None:
+                raise ValueError("Either the trains task or the project name and task name have to be provided")
+            self.task = Task.init(project_name=projectName, task_name=taskName, reuse_last_task_id=False)
+        else:
+            if projectName is not None:
+                log.warning(
+                    f"projectName parameter with value {projectName} passed even though task has been given, "
+                    f"will ignore this parameter"
+                )
+            if taskName is not None:
+                log.warning(
+                    f"taskName parameter with value {taskName} passed even though task has been given, "
+                    f"will ignore this parameter"
+                )
+            self.task = task
+        self.logger = self.task.get_logger()
+        super().__init__(additionalLoggingValuesDict=additionalLoggingValuesDict)
+
+    def _trackValues(self, valuesDict):
+        self.task.connect(valuesDict)


### PR DESCRIPTION
This PR contains minor overall improvements and a new feature: support for tracking experiments with trains.

There is a breaking change: the previously obligatory parameter isRegression in MultiEvaluationUtil is gone. Since models are passed and instantiated anyway, we can infer the correct value from them

On another note: the code is getting a bit hard to read due to formatting. I grew quite fond of the black formatter after using it for a few months now (although it took some time getting used to it). It does not enforce PEP8 as far as I know. If you don't mind, I would open a separate PR which enhances the build and uses this formatter in the CI and as pre-commit hook. There is even some option for running the initial reformatting without losing all of the git history.

EDIT: to be completely strict, there is a second breaking change in the structure of generics in EvaluationUtil. This would only affect users who inherited from EvaluationUtil in their own code. I strongly suspect that the set of these people is empty