### PR TITLE
Improve build

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -37,6 +37,13 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: "3.7"
+      - name: Cache tox envs and pip packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/pip
+            .tox
+          key: ${{runner.os}}-${{github.ref}}-${{hashFiles('requirements.txt', 'setup.py', 'tox.ini')}}
       - name: Install Tox and Python Packages
         run: pip install tox
       - name: Run Tox

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.to
 
 [tox]
-envlist = py, docs, report
+envlist = py, py_latest_dependencies, docs, report
 isolated_build = True
 
 [testenv:py]
@@ -27,6 +27,19 @@ deps =
 ;     and lead to non-ending builds (2.5h+) on github. This dependency should be installable with pip install sensai[torch] though...
     pytorch-lightning~=1.1
     -rrequirements.txt
+extras =
+    full
+
+# TODO or not TODO: notebooks are not executed here again (the build would become very slow) so they are not tested with
+#   latest dependencies. Hopefully, this is not a problem
+[testenv:py_latest_dependencies]
+commands =
+    pytest
+deps =
+    pytest
+;   TODO: For some reason including this into setup.py makes things slow locally, fail silently on gitlab
+;     and lead to non-ending builds (2.5h+) on github. This dependency should be installable with pip install sensai[torch] though...
+    pytorch-lightning>=1.1
 extras =
     full
 


### PR DESCRIPTION
Closes #31 #22 

The caching is extra-careful: there is only one cache key which is pinned to the branch and to requirements.txt, setup.py and tox.ini. Any change in those files invalidate the previous cache